### PR TITLE
Added retry functionality to circuit breaker

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -20,6 +20,10 @@ Sets whether or not the fallback is executed on failure, even when the circuit i
 +++
 Sets the maximum number of failures before opening the circuit.
 +++
+|[[maxRetries]]`maxRetries`|`Number (int)`|
++++
+Configures the number of times the circuit breaker tries to redo the operation before failing.
++++
 |[[notificationAddress]]`notificationAddress`|`String`|
 +++
 Sets the event bus address on which the circuit breaker publish its state change.

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -161,6 +161,12 @@ breaker.execute({ future ->
 
 ----
 
+You can also specify how often the circuit breaker should try your code before failing with
+`link:../../groovydoc/io/vertx/groovy/circuitbreaker/CircuitBreaker.html#setMaxRetries-int-[setMaxRetries]`.
+If you set this to something higher than 0 your code gets executed several times before finally failing
+in the last execution. If the code succeeded in one of the retries your handler gets notified and any
+retries left are skipped. Retries are only supported when the circuit is closed.
+
 == Callbacks
 
 You can also configures callbacks invoked when the circuit is opened or closed:

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -160,6 +160,12 @@ breaker.execute(
     });
 ----
 
+You can also specify how often the circuit breaker should try your code before failing with
+`link:../../apidocs/io/vertx/circuitbreaker/CircuitBreakerOptions.html#setMaxRetries-int-[setMaxRetries]`.
+If you set this to something higher than 0 your code gets executed several times before finally failing
+in the last execution. If the code succeeded in one of the retries your handler gets notified and any
+retries left are skipped. Retries are only supported when the circuit is closed.
+
 == Callbacks
 
 You can also configures callbacks invoked when the circuit is opened or closed:

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -161,6 +161,12 @@ breaker.execute(function (future) {
 
 ----
 
+You can also specify how often the circuit breaker should try your code before failing with
+`link:../dataobjects.html#CircuitBreakerOptions#setMaxRetries[maxRetries]`.
+If you set this to something higher than 0 your code gets executed several times before finally failing
+in the last execution. If the code succeeded in one of the retries your handler gets notified and any
+retries left are skipped. Retries are only supported when the circuit is closed.
+
 == Callbacks
 
 You can also configures callbacks invoked when the circuit is opened or closed:

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -161,6 +161,12 @@ breaker.execute() { |future|
 
 ----
 
+You can also specify how often the circuit breaker should try your code before failing with
+`link:../dataobjects.html#CircuitBreakerOptions#set_max_retries-instance_method[maxRetries]`.
+If you set this to something higher than 0 your code gets executed several times before finally failing
+in the last execution. If the code succeeded in one of the retries your handler gets notified and any
+retries left are skipped. Retries are only supported when the circuit is closed.
+
 == Callbacks
 
 You can also configures callbacks invoked when the circuit is opened or closed:

--- a/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
+++ b/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
@@ -33,6 +33,9 @@ public class CircuitBreakerOptionsConverter {
     if (json.getValue("maxFailures") instanceof Number) {
       obj.setMaxFailures(((Number)json.getValue("maxFailures")).intValue());
     }
+    if (json.getValue("maxRetries") instanceof Number) {
+      obj.setMaxRetries(((Number)json.getValue("maxRetries")).intValue());
+    }
     if (json.getValue("notificationAddress") instanceof String) {
       obj.setNotificationAddress((String)json.getValue("notificationAddress"));
     }
@@ -50,6 +53,7 @@ public class CircuitBreakerOptionsConverter {
   public static void toJson(CircuitBreakerOptions obj, JsonObject json) {
     json.put("fallbackOnFailure", obj.isFallbackOnFailure());
     json.put("maxFailures", obj.getMaxFailures());
+    json.put("maxRetries", obj.getMaxRetries());
     if (obj.getNotificationAddress() != null) {
       json.put("notificationAddress", obj.getNotificationAddress());
     }

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -57,6 +57,11 @@ public class CircuitBreakerOptions {
    */
   private static final long DEFAULT_NOTIFICATION_PERIOD = 2000;
 
+  /**
+   * Default number of retries.
+   */
+  private static final int DEFAULT_MAX_RETRIES = 0;
+
   private long timeout = DEFAULT_TIMEOUT;
 
   private int maxFailures = DEFAULT_MAX_FAILURES;
@@ -69,6 +74,8 @@ public class CircuitBreakerOptions {
 
   private long notificationPeriod = DEFAULT_NOTIFICATION_PERIOD;
 
+  private int maxRetries = DEFAULT_MAX_RETRIES;
+
   /**
    * Creates a new instance of {@link CircuitBreakerOptions} using the default values.
    */
@@ -79,7 +86,8 @@ public class CircuitBreakerOptions {
   /**
    * Creates a new instance of {@link CircuitBreakerOptions} by copying the other instance.
    *
-   * @param other the instance fo copy
+   * @param other
+   *          the instance fo copy
    */
   public CircuitBreakerOptions(CircuitBreakerOptions other) {
     this.timeout = other.timeout;
@@ -88,6 +96,7 @@ public class CircuitBreakerOptions {
     this.notificationAddress = other.notificationAddress;
     this.notificationPeriod = other.notificationPeriod;
     this.resetTimeout = other.resetTimeout;
+    this.maxRetries = other.maxRetries;
   }
 
   /**
@@ -218,6 +227,24 @@ public class CircuitBreakerOptions {
    */
   public CircuitBreakerOptions setNotificationPeriod(long notificationPeriod) {
     this.notificationPeriod = notificationPeriod;
+    return this;
+  }
+
+  /**
+   * @return the number of times the circuit breaker tries to redo the operation before failing
+   */
+  public int getMaxRetries() {
+    return maxRetries;
+  }
+
+  /**
+   * Configures the number of times the circuit breaker tries to redo the operation before failing.
+   *
+   * @param maxRetries the number of retries, 0 to disable this feature.
+   * @return the current {@link CircuitBreaker} instance
+   */
+  public CircuitBreakerOptions setMaxRetries(int maxRetries) {
+    this.maxRetries = maxRetries;
     return this;
   }
 }

--- a/src/main/java/io/vertx/circuitbreaker/package-info.java
+++ b/src/main/java/io/vertx/circuitbreaker/package-info.java
@@ -99,6 +99,12 @@
  * {@link examples.Examples#example4(io.vertx.core.Vertx)}
  * ----
  *
+ * You can also specify how often the circuit breaker should try your code before failing with
+ * {@link io.vertx.circuitbreaker.CircuitBreakerOptions#setMaxRetries(int)}.
+ * If you set this to something higher than 0 your code gets executed several times before finally failing
+ * in the last execution. If the code succeeded in one of the retries your handler gets notified and any
+ * retries left are skipped. Retries are only supported when the circuit is closed.
+ *
  * == Callbacks
  *
  * You can also configures callbacks invoked when the circuit is opened or closed:


### PR DESCRIPTION
As I already mentioned in the vertx-dev group, this pull request tries to add retry functionality to the circuit breaker. 
It works with a simple contract: If the number of retries are configured, the cb will execute the operation x-times until it either succeeds in some run or does not at all, in which case the operation is marked as failed with the last failure or timeout.

I currently only do this when the cb is in closed state, but if its wanted this could be easily added to the half-open state too.

Please let me know if you want me to change something before accepting, happy to help :)

PS: I will sign the Eclipse SLA as soon as my account gets activated.

Signed-off-by: Jan Kerkenhoff <jan.kerkenhoff@braintags.de>