### PR TITLE
Calculate metrics using buckets.

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -24,6 +24,14 @@ Sets the maximum number of failures before opening the circuit.
 +++
 Configures the number of times the circuit breaker tries to redo the operation before failing.
 +++
+|[[metricsRollingBuckets]]`metricsRollingBuckets`|`Number (int)`|
++++
+Sets the configured number of buckets the rolling window is divided into.
+
+ The following must be true - metrics.rollingStats.timeInMilliseconds % metrics.rollingStats.numBuckets == 0 - otherwise it will throw an exception.
+
+ In other words, 10000/10 is okay, so is 10000/20 but 10000/7 is not.
++++
 |[[metricsRollingWindow]]`metricsRollingWindow`|`Number (long)`|
 +++
 Sets the rolling window used for metrics.

--- a/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
+++ b/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
@@ -36,6 +36,9 @@ public class CircuitBreakerOptionsConverter {
     if (json.getValue("maxRetries") instanceof Number) {
       obj.setMaxRetries(((Number)json.getValue("maxRetries")).intValue());
     }
+    if (json.getValue("metricsRollingBuckets") instanceof Number) {
+      obj.setMetricsRollingBuckets(((Number)json.getValue("metricsRollingBuckets")).intValue());
+    }
     if (json.getValue("metricsRollingWindow") instanceof Number) {
       obj.setMetricsRollingWindow(((Number)json.getValue("metricsRollingWindow")).longValue());
     }
@@ -57,6 +60,7 @@ public class CircuitBreakerOptionsConverter {
     json.put("fallbackOnFailure", obj.isFallbackOnFailure());
     json.put("maxFailures", obj.getMaxFailures());
     json.put("maxRetries", obj.getMaxRetries());
+    json.put("metricsRollingBuckets", obj.getMetricsRollingBuckets());
     json.put("metricsRollingWindow", obj.getMetricsRollingWindow());
     if (obj.getNotificationAddress() != null) {
       json.put("notificationAddress", obj.getNotificationAddress());

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -63,6 +63,11 @@ public class CircuitBreakerOptions {
   public static final long DEFAULT_METRICS_ROLLING_WINDOW = 10000;
 
   /**
+   * Default number of buckets used for the rolling window.
+   */
+  public static final int DEFAULT_METRICS_ROLLING_BUCKETS = 10;
+
+  /**
    * Default number of retries.
    */
   private static final int DEFAULT_MAX_RETRIES = 0;
@@ -105,6 +110,11 @@ public class CircuitBreakerOptions {
   private long metricsRollingWindow = DEFAULT_METRICS_ROLLING_WINDOW;
 
   /**
+   * The number of buckets used for the metric rolling window.
+   */
+  private int metricsRollingBuckets = DEFAULT_METRICS_ROLLING_BUCKETS;
+
+  /**
    * Creates a new instance of {@link CircuitBreakerOptions} using the default values.
    */
   public CircuitBreakerOptions() {
@@ -124,6 +134,7 @@ public class CircuitBreakerOptions {
     this.notificationPeriod = other.notificationPeriod;
     this.resetTimeout = other.resetTimeout;
     this.maxRetries = other.maxRetries;
+    this.metricsRollingBuckets = other.metricsRollingBuckets;
   }
 
   /**
@@ -250,7 +261,7 @@ public class CircuitBreakerOptions {
    * current state.
    *
    * @param notificationPeriod the period, 0 to disable this feature.
-   * @return the current {@link CircuitBreaker} instance
+   * @return the current {@link CircuitBreakerOptions} instance
    */
   public CircuitBreakerOptions setNotificationPeriod(long notificationPeriod) {
     this.notificationPeriod = notificationPeriod;
@@ -268,10 +279,32 @@ public class CircuitBreakerOptions {
    * Sets the rolling window used for metrics.
    *
    * @param metricsRollingWindow the period in milliseconds.
-   * @return the current {@link CircuitBreaker} instance
+   * @return the current {@link CircuitBreakerOptions} instance
    */
   public CircuitBreakerOptions setMetricsRollingWindow(long metricsRollingWindow) {
     this.metricsRollingWindow = metricsRollingWindow;
+    return this;
+  }
+
+  /**
+   * @return the configured number of buckets the rolling window is divided into.
+   */
+  public int getMetricsRollingBuckets() {
+    return metricsRollingBuckets;
+  }
+
+  /**
+   * Sets the configured number of buckets the rolling window is divided into.
+   *
+   * The following must be true - metrics.rollingStats.timeInMilliseconds % metrics.rollingStats.numBuckets == 0 - otherwise it will throw an exception.
+   *
+   * In other words, 10000/10 is okay, so is 10000/20 but 10000/7 is not.
+   *
+   * @param metricsRollingBuckets the number of rolling buckets.
+   * @return the current {@link CircuitBreakerOptions} instance
+   */
+  public CircuitBreakerOptions setMetricsRollingBuckets(int metricsRollingBuckets) {
+    this.metricsRollingBuckets = metricsRollingBuckets;
     return this;
   }
 
@@ -286,7 +319,7 @@ public class CircuitBreakerOptions {
    * Configures the number of times the circuit breaker tries to redo the operation before failing.
    *
    * @param maxRetries the number of retries, 0 to disable this feature.
-   * @return the current {@link CircuitBreaker} instance
+   * @return the current {@link CircuitBreakerOptions} instance
    */
   public CircuitBreakerOptions setMaxRetries(int maxRetries) {
     this.maxRetries = maxRetries;

--- a/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreakerOptions.kt
+++ b/src/main/kotlin/io/vertx/kotlin/circuitbreaker/CircuitBreakerOptions.kt
@@ -10,6 +10,7 @@ import io.vertx.circuitbreaker.CircuitBreakerOptions
  * @param fallbackOnFailure  Sets whether or not the fallback is executed on failure, even when the circuit is closed.
  * @param maxFailures  Sets the maximum number of failures before opening the circuit.
  * @param maxRetries  Configures the number of times the circuit breaker tries to redo the operation before failing.
+ * @param metricsRollingBuckets  Sets the configured number of buckets the rolling window is divided into. The following must be true - metrics.rollingStats.timeInMilliseconds % metrics.rollingStats.numBuckets == 0 - otherwise it will throw an exception. In other words, 10000/10 is okay, so is 10000/20 but 10000/7 is not.
  * @param metricsRollingWindow  Sets the rolling window used for metrics.
  * @param notificationAddress  Sets the event bus address on which the circuit breaker publish its state change.
  * @param notificationPeriod  Configures the period in milliseconds where the circuit breaker send a notification on the event bus with its current state.
@@ -23,6 +24,7 @@ fun CircuitBreakerOptions(
   fallbackOnFailure: Boolean? = null,
   maxFailures: Int? = null,
   maxRetries: Int? = null,
+  metricsRollingBuckets: Int? = null,
   metricsRollingWindow: Long? = null,
   notificationAddress: String? = null,
   notificationPeriod: Long? = null,
@@ -37,6 +39,9 @@ fun CircuitBreakerOptions(
   }
   if (maxRetries != null) {
     this.setMaxRetries(maxRetries)
+  }
+  if (metricsRollingBuckets != null) {
+    this.setMetricsRollingBuckets(metricsRollingBuckets)
   }
   if (metricsRollingWindow != null) {
     this.setMetricsRollingWindow(metricsRollingWindow)


### PR DESCRIPTION
Rewrite the metrics calculation.  It replaces the window array which
a data sample for every operation with a fixed size list of buckets.
This resolves #17 which describes this memory leak.