### PR TITLE
Small test for invalid bucket size

### DIFF
--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
@@ -860,4 +860,11 @@ public class CircuitBreakerImplTest {
 
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidBucketSize() {
+    CircuitBreakerOptions options = new CircuitBreakerOptions()
+      .setMetricsRollingBuckets(7);
+    CircuitBreaker.create("test", vertx, options);
+  }
+
 }


### PR DESCRIPTION
Before #18 was merged, I was looking if I could add some extra test cases.

The only one I could find was this one, which brings the line coverage of `CircuitBreakerMetrics` to 98.1%.