### PR TITLE
Add automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
   <properties>
     <hystrix.version>1.5.2</hystrix.version>
     <codegen.rxjava.deprecated>true</codegen.rxjava.deprecated>
+    <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 
   <dependencyManagement>

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Automatic-Module-Name: io.vertx.circuitbreaker
+


### PR DESCRIPTION
Signed-off-by: afloarea <adrianfloarea07@yahoo.com>

Motivation:

Add automatic module name as per vert-x3/issues#524

NOTE / FYI: on `mvn clean package -DskipTests` compilation failed with:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project vertx-circuit-breaker: Compilation failure
[ERROR] /home/afloarea/Repositories/vertx/vertx-circuit-breaker/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerMetrics.java:[29,82] cannot find symbol
[ERROR]   symbol:   method getNodeID()
[ERROR]   location: interface io.vertx.core.spi.cluster.ClusterManager
```
The line that caused the issue:
```
this.node = vertx.isClustered() ? ((VertxInternal) vertx).getClusterManager().getNodeID() : "local";
```

In order to test that the jar had the automatic module name I temporarily changed the line to `this.node = "local"` 