### PR TITLE
Changes in EventBus notification defaults

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -122,10 +122,17 @@ such a callback with {@link io.vertx.circuitbreaker.CircuitBreaker#halfOpenHandl
 
 == Event bus notification
 
-Every time the circuit state changes, an event is published on the event bus. The address on which the events are
-sent is configurable with
-{@link io.vertx.circuitbreaker.CircuitBreakerOptions#setNotificationAddress(java.lang.String)}. If `null` is
-passed to this method, the notifications are disabled. By default, the used address is `vertx.circuit-breaker`.
+Every time the circuit state changes, an event can be published on the event bus.
+
+To enable this feature, set the {@link io.vertx.circuitbreaker.CircuitBreakerOptions#setNotificationAddress(java.lang.String) notification address} to a value that is not `null`:
+
+[source,$lang]
+----
+{@link examples.CircuitBreakerExamples#enableNotifications}
+----
+
+NOTE: When enabled, notifications are, by default, delivered only to local consumers.
+If the notification must be sent to all consumers in a cluster, you can change this behavior with {@link io.vertx.circuitbreaker.CircuitBreakerOptions#setNotificationLocalOnly}.
 
 Each event contains a Json Object with:
 
@@ -167,8 +174,8 @@ a SSE stream sending the metrics. This stream is provided by the
 In the Hystrix Dashboard, configure the stream url like: `http://localhost:8080/metrics`. The dashboard now consumes
 the metrics from the Vert.x circuit breakers.
 
-Notice that the metrics are collected by the Vert.x Web handler using the event bus notifications. If you don't use
-the default notification address, you need to pass it when creating the metrics handler.
+IMPORTANT: The metrics are collected by the Vert.x Web handler using <<Event bus notification>>.
+The feature must be enabled and, if you don't use the default notification address, you need to pass it when creating the metrics handler.
 
 [language, java]
 ----

--- a/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
+++ b/src/main/generated/io/vertx/circuitbreaker/CircuitBreakerOptionsConverter.java
@@ -55,6 +55,11 @@ public class CircuitBreakerOptionsConverter {
             obj.setNotificationAddress((String)member.getValue());
           }
           break;
+        case "notificationLocalOnly":
+          if (member.getValue() instanceof Boolean) {
+            obj.setNotificationLocalOnly((Boolean)member.getValue());
+          }
+          break;
         case "notificationPeriod":
           if (member.getValue() instanceof Number) {
             obj.setNotificationPeriod(((Number)member.getValue()).longValue());
@@ -88,6 +93,7 @@ public class CircuitBreakerOptionsConverter {
     if (obj.getNotificationAddress() != null) {
       json.put("notificationAddress", obj.getNotificationAddress());
     }
+    json.put("notificationLocalOnly", obj.isNotificationLocalOnly());
     json.put("notificationPeriod", obj.getNotificationPeriod());
     json.put("resetTimeout", obj.getResetTimeout());
     json.put("timeout", obj.getTimeout());

--- a/src/main/java/examples/CircuitBreakerExamples.java
+++ b/src/main/java/examples/CircuitBreakerExamples.java
@@ -16,14 +16,13 @@
 
 package examples;
 
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.circuitbreaker.HystrixMetricHandler;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.circuitbreaker.CircuitBreaker;
-import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 
@@ -187,9 +186,11 @@ public class CircuitBreakerExamples {
   }
 
   public void example7(Vertx vertx) {
-    // Create the circuit breaker as usual.
-    CircuitBreaker breaker = CircuitBreaker.create("my-circuit-breaker", vertx);
-    CircuitBreaker breaker2 = CircuitBreaker.create("my-second-circuit-breaker", vertx);
+    // Enable notifications
+    CircuitBreakerOptions options = new CircuitBreakerOptions()
+      .setNotificationAddress(CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
+    CircuitBreaker breaker = CircuitBreaker.create("my-circuit-breaker", vertx, new CircuitBreakerOptions(options));
+    CircuitBreaker breaker2 = CircuitBreaker.create("my-second-circuit-breaker", vertx, new CircuitBreakerOptions(options));
 
     // Create a Vert.x Web router
     Router router = Router.router(vertx);
@@ -225,5 +226,9 @@ public class CircuitBreakerExamples {
               }
             })).onComplete(promise);
       });
+  }
+
+  public void enableNotifications(CircuitBreakerOptions options) {
+    options.setNotificationAddress(CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
   }
 }

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -48,7 +48,12 @@ public class CircuitBreakerOptions {
   public static final long DEFAULT_RESET_TIMEOUT = 30000;
 
   /**
-   * Default address on which the circuit breakers are sending their update.
+   * Whether circuit breaker state should be delivered only to local consumers by default = {@code true}.
+   */
+  public static final boolean DEFAULT_NOTIFICATION_LOCAL_ONLY = true;
+
+  /**
+   * A default address on which the circuit breakers can send their updates.
    */
   public static final String DEFAULT_NOTIFICATION_ADDRESS = "vertx.circuit-breaker";
 
@@ -76,7 +81,7 @@ public class CircuitBreakerOptions {
    * The default rolling window span in milliseconds.
    */
   private static final int DEFAULT_FAILURES_ROLLING_WINDOW = 10000;
-  
+
   /**
    * The operation timeout.
    */
@@ -98,9 +103,14 @@ public class CircuitBreakerOptions {
   private long resetTimeout = DEFAULT_RESET_TIMEOUT;
 
   /**
+   * Whether circuit breaker state should be delivered only to local consumers.
+   */
+  private boolean notificationLocalOnly = DEFAULT_NOTIFICATION_LOCAL_ONLY;
+
+  /**
    * The event bus address on which the circuit breaker state is published.
    */
-  private String notificationAddress = DEFAULT_NOTIFICATION_ADDRESS;
+  private String notificationAddress = null;
 
   /**
    * The state publication period in ms.
@@ -121,7 +131,7 @@ public class CircuitBreakerOptions {
    * The number of buckets used for the metric rolling window.
    */
   private int metricsRollingBuckets = DEFAULT_METRICS_ROLLING_BUCKETS;
-  
+
   /**
    * The failure rolling window in ms.
    */
@@ -143,6 +153,7 @@ public class CircuitBreakerOptions {
     this.timeout = other.timeout;
     this.maxFailures = other.maxFailures;
     this.fallbackOnFailure = other.fallbackOnFailure;
+    this.notificationLocalOnly = other.notificationLocalOnly;
     this.notificationAddress = other.notificationAddress;
     this.notificationPeriod = other.notificationPeriod;
     this.resetTimeout = other.resetTimeout;
@@ -246,6 +257,24 @@ public class CircuitBreakerOptions {
   }
 
   /**
+   * @return {@code true} if circuit breaker state should be delivered only to local consumers, otherwise {@code false}
+   */
+  public boolean isNotificationLocalOnly() {
+    return notificationLocalOnly;
+  }
+
+  /**
+   * Whether circuit breaker state should be delivered only to local consumers.
+   *
+   * @param notificationLocalOnly {@code true} if circuit breaker state should be delivered only to local consumers, otherwise {@code false}
+   * @return the current {@link CircuitBreakerOptions} instance
+   */
+  public CircuitBreakerOptions setNotificationLocalOnly(boolean notificationLocalOnly) {
+    this.notificationLocalOnly = notificationLocalOnly;
+    return this;
+  }
+
+  /**
    * @return the eventbus address on which the circuit breaker events are published. {@code null} if this feature has
    * been disabled.
    */
@@ -307,7 +336,7 @@ public class CircuitBreakerOptions {
   public long getFailuresRollingWindow() {
     return failuresRollingWindow;
   }
-  
+
   /**
    * Sets the rolling window used for metrics.
    *
@@ -318,7 +347,7 @@ public class CircuitBreakerOptions {
     this.failuresRollingWindow = failureRollingWindow;
     return this;
   }
-  
+
   /**
    * @return the configured number of buckets the rolling window is divided into.
    */

--- a/src/main/java/io/vertx/circuitbreaker/HystrixMetricHandler.java
+++ b/src/main/java/io/vertx/circuitbreaker/HystrixMetricHandler.java
@@ -16,24 +16,35 @@ import io.vertx.ext.web.RoutingContext;
 public interface HystrixMetricHandler extends Handler<RoutingContext> {
 
   /**
-   * Creates the handler, using the default notification address.
+   * Creates the handler, using the default notification address and listening to local messages only.
    *
    * @param vertx the Vert.x instance
    * @return the handler
    */
   static HystrixMetricHandler create(Vertx vertx) {
-    return new HystrixMetricEventStream(vertx, CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
+    return create(vertx, CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
+  }
+
+  /**
+   * Creates the handler, listening only to local messages.
+   *
+   * @param vertx the Vert.x instance
+   * @param address the address to listen on the event bus
+   * @return the handler
+   */
+  static HystrixMetricHandler create(Vertx vertx, String address) {
+    return create(vertx, address, CircuitBreakerOptions.DEFAULT_NOTIFICATION_LOCAL_ONLY);
   }
 
   /**
    * Creates the handler.
    *
-   * @param vertx   the Vert.x instance
+   * @param vertx the Vert.x instance
    * @param address the address to listen on the event bus
+   * @param localOnly whether the consumer should only receive messages sent from this Vert.x instance
    * @return the handler
    */
-  static HystrixMetricHandler create(Vertx vertx, String address) {
-    return new HystrixMetricEventStream(vertx, address);
+  static HystrixMetricHandler create(Vertx vertx, String address, boolean localOnly) {
+    return new HystrixMetricEventStream(vertx, address, localOnly);
   }
-
 }

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -26,6 +26,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -157,7 +158,9 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   private synchronized void sendUpdateOnEventBus() {
     String address = options.getNotificationAddress();
     if (address != null) {
-      vertx.eventBus().publish(address, metrics.toJson());
+      DeliveryOptions deliveryOptions = new DeliveryOptions()
+        .setLocalOnly(options.isNotificationLocalOnly());
+      vertx.eventBus().publish(address, metrics.toJson(), deliveryOptions);
     }
   }
 

--- a/src/test/java/io/vertx/circuitbreaker/impl/HystrixMetricEventStreamTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/HystrixMetricEventStreamTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static io.vertx.circuitbreaker.CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -81,9 +82,12 @@ public class HystrixMetricEventStreamTest {
   @Test
   @Repeat(10)
   public void test() {
-    breakerA = CircuitBreaker.create("A", vertx, new CircuitBreakerOptions().setTimeout(1000));
-    breakerB = CircuitBreaker.create("B", vertx, new CircuitBreakerOptions().setTimeout(1000));
-    breakerC = CircuitBreaker.create("C", vertx, new CircuitBreakerOptions().setTimeout(1000));
+    CircuitBreakerOptions options = new CircuitBreakerOptions()
+      .setNotificationAddress(DEFAULT_NOTIFICATION_ADDRESS)
+      .setTimeout(1000);
+    breakerA = CircuitBreaker.create("A", vertx, new CircuitBreakerOptions(options));
+    breakerB = CircuitBreaker.create("B", vertx, new CircuitBreakerOptions(options));
+    breakerC = CircuitBreaker.create("C", vertx, new CircuitBreakerOptions(options));
 
     Router router = Router.router(vertx);
     router.get("/metrics").handler(HystrixMetricHandler.create(vertx));

--- a/src/test/java/io/vertx/circuitbreaker/metrics/DashboardExample.java
+++ b/src/test/java/io/vertx/circuitbreaker/metrics/DashboardExample.java
@@ -3,7 +3,6 @@ package io.vertx.circuitbreaker.metrics;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.circuitbreaker.HystrixMetricHandler;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -11,6 +10,8 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 import java.util.Random;
+
+import static io.vertx.circuitbreaker.CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
@@ -22,15 +23,16 @@ public class DashboardExample {
   public static void main(String[] args) {
     Vertx vertx = Vertx.vertx();
     CircuitBreakerOptions options = new CircuitBreakerOptions()
+      .setNotificationAddress(DEFAULT_NOTIFICATION_ADDRESS)
       .setFallbackOnFailure(true)
       .setMaxFailures(10)
       .setResetTimeout(5000)
       .setTimeout(1000)
       .setMetricsRollingWindow(10000);
 
-    CircuitBreaker cba = CircuitBreaker.create("A", vertx, options);
-    CircuitBreaker cbb = CircuitBreaker.create("B", vertx, options);
-    CircuitBreaker cbc = CircuitBreaker.create("C", vertx, options);
+    CircuitBreaker cba = CircuitBreaker.create("A", vertx, new CircuitBreakerOptions(options));
+    CircuitBreaker cbb = CircuitBreaker.create("B", vertx, new CircuitBreakerOptions(options));
+    CircuitBreaker cbc = CircuitBreaker.create("C", vertx, new CircuitBreakerOptions(options));
 
     Router router = Router.router(vertx);
     router.get("/metrics").handler(HystrixMetricHandler.create(vertx));


### PR DESCRIPTION
Closes #51

To avoid unnecessary traffic, circuit breaker state changes notifications are now by default:

- disabled
- sent only to local consumers