### PR TITLE
Disable metrics computation by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
       <version>2.1.12</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -83,6 +84,12 @@
       <version>${hystrix.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hdrhistogram</groupId>
+          <artifactId>HdrHistogram</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -131,15 +131,39 @@ To enable this feature, set the {@link io.vertx.circuitbreaker.CircuitBreakerOpt
 {@link examples.CircuitBreakerExamples#enableNotifications}
 ----
 
-NOTE: When enabled, notifications are, by default, delivered only to local consumers.
+The event contains circuit breaker metrics which computation requires the following dependency to be added the _dependencies_ section of your build descriptor:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>org.hdrhistogram</groupId>
+  <artifactId>HdrHistogram</artifactId>
+  <version>2.1.12</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile 'org.hdrhistogram:HdrHistogram:2.1.12'
+----
+
+[NOTE]
+====
+When enabled, notifications are, by default, delivered only to local consumers.
 If the notification must be sent to all consumers in a cluster, you can change this behavior with {@link io.vertx.circuitbreaker.CircuitBreakerOptions#setNotificationLocalOnly}.
+====
 
 Each event contains a Json Object with:
 
-* `state` : the new circuit breaker state (`OPEN`, `CLOSED`, `HALF_OPEN`)
-* `name` : the name of the circuit breaker
-* `failures` : the number of failures
-* `node` : the identifier of the node (`local` if Vert.x is not running in cluster mode)
+* `state`: the new circuit breaker state (`OPEN`, `CLOSED`, `HALF_OPEN`)
+* `name`: the name of the circuit breaker
+* `failures`: the number of failures
+* `node`: the identifier of the node (`local` if Vert.x is not running in cluster mode)
+* metrics
 
 == The half-open state
 

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -16,17 +16,10 @@
 
 package io.vertx.circuitbreaker.impl;
 
-import io.vertx.circuitbreaker.CircuitBreaker;
-import io.vertx.circuitbreaker.CircuitBreakerOptions;
-import io.vertx.circuitbreaker.CircuitBreakerState;
-import io.vertx.circuitbreaker.OpenCircuitException;
-import io.vertx.circuitbreaker.TimeoutException;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import io.vertx.circuitbreaker.*;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.json.JsonObject;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -60,7 +53,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
 
   private final AtomicInteger passed = new AtomicInteger();
 
-  private CircuitBreakerMetrics metrics;
+  private final CircuitBreakerMetrics metrics;
   private Function<Integer, Long> retryPolicy = retry -> 0L;
 
   public CircuitBreakerImpl(String name, Vertx vertx, CircuitBreakerOptions options) {
@@ -75,24 +68,30 @@ public class CircuitBreakerImpl implements CircuitBreaker {
       this.options = new CircuitBreakerOptions(options);
     }
 
-    this.metrics = new CircuitBreakerMetrics(vertx, this, options);
-    this.rollingFailures = new RollingCounter(options.getFailuresRollingWindow() / 1000, TimeUnit.SECONDS);
+    this.rollingFailures = new RollingCounter(this.options.getFailuresRollingWindow() / 1000, TimeUnit.SECONDS);
 
-    sendUpdateOnEventBus();
-
-    if (this.options.getNotificationPeriod() > 0) {
-      this.periodicUpdateTask = vertx.setPeriodic(this.options.getNotificationPeriod(), l -> sendUpdateOnEventBus());
+    if (this.options.getNotificationAddress() != null) {
+      this.metrics = new CircuitBreakerMetrics(vertx, this, this.options);
+      sendUpdateOnEventBus();
+      if (this.options.getNotificationPeriod() > 0) {
+        this.periodicUpdateTask = vertx.setPeriodic(this.options.getNotificationPeriod(), l -> sendUpdateOnEventBus());
+      } else {
+        this.periodicUpdateTask = -1;
+      }
     } else {
+      this.metrics = null;
       this.periodicUpdateTask = -1;
     }
   }
 
   @Override
   public CircuitBreaker close() {
-    if (this.periodicUpdateTask != -1) {
-      vertx.cancelTimer(this.periodicUpdateTask);
+    if (metrics != null) {
+      if (periodicUpdateTask != -1) {
+        vertx.cancelTimer(periodicUpdateTask);
+      }
+      metrics.close();
     }
-    metrics.close();
     return this;
   }
 
@@ -156,11 +155,10 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   }
 
   private synchronized void sendUpdateOnEventBus() {
-    String address = options.getNotificationAddress();
-    if (address != null) {
+    if (metrics != null) {
       DeliveryOptions deliveryOptions = new DeliveryOptions()
         .setLocalOnly(options.isNotificationLocalOnly());
-      vertx.eventBus().publish(address, metrics.toJson(), deliveryOptions);
+      vertx.eventBus().publish(options.getNotificationAddress(), metrics.toJson(), deliveryOptions);
     }
   }
 
@@ -212,7 +210,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
       currentState = state;
     }
 
-    CircuitBreakerMetrics.Operation call = metrics.enqueue();
+    CircuitBreakerMetrics.Operation call = metrics != null ? metrics.enqueue() : null;
 
     // this future object tracks the completion of the operation
     // This future is marked as failed on operation failures and timeout.
@@ -223,14 +221,18 @@ public class CircuitBreakerImpl implements CircuitBreaker {
         context.runOnContext(v -> {
           if (event.failed()) {
             incrementFailures();
-            call.failed();
+            if (call != null) {
+              call.failed();
+            }
             if (options.isFallbackOnFailure()) {
               invokeFallback(event.cause(), userFuture, fallback, call);
             } else {
               userFuture.fail(event.cause());
             }
           } else {
-            call.complete();
+            if (call != null) {
+              call.complete();
+            }
             reset();
             userFuture.complete(event.result());
           }
@@ -245,7 +247,9 @@ public class CircuitBreakerImpl implements CircuitBreaker {
       }
     } else if (currentState == CircuitBreakerState.OPEN) {
       // Fallback immediately
-      call.shortCircuited();
+      if (call != null) {
+        call.shortCircuited();
+      }
       invokeFallback(OpenCircuitException.INSTANCE, userFuture, fallback, call);
     } else if (currentState == CircuitBreakerState.HALF_OPEN) {
       if (passed.incrementAndGet() == 1) {
@@ -253,14 +257,18 @@ public class CircuitBreakerImpl implements CircuitBreaker {
           context.runOnContext(v -> {
             if (event.failed()) {
               open();
-              call.failed();
+              if (call != null) {
+                call.failed();
+              }
               if (options.isFallbackOnFailure()) {
                 invokeFallback(event.cause(), userFuture, fallback, call);
               } else {
                 userFuture.fail(event.cause());
               }
             } else {
-              call.complete();
+              if (call != null) {
+                call.complete();
+              }
               reset();
               userFuture.complete(event.result());
             }
@@ -270,7 +278,9 @@ public class CircuitBreakerImpl implements CircuitBreaker {
         executeOperation(context, command, operationResult, call);
       } else {
         // Not selected, fallback.
-        call.shortCircuited();
+        if (call != null) {
+          call.shortCircuited();
+        }
         invokeFallback(OpenCircuitException.INSTANCE, userFuture, fallback, call);
       }
     }
@@ -340,11 +350,15 @@ public class CircuitBreakerImpl implements CircuitBreaker {
 
     try {
       T apply = fallback.apply(reason);
-      operation.fallbackSucceed();
+      if (operation != null) {
+        operation.fallbackSucceed();
+      }
       userFuture.complete(apply);
     } catch (Exception e) {
       userFuture.fail(e);
-      operation.fallbackFailed();
+      if (operation != null) {
+        operation.fallbackFailed();
+      }
     }
   }
 
@@ -437,8 +451,8 @@ public class CircuitBreakerImpl implements CircuitBreaker {
    *
    * @return retrieve the metrics.
    */
-  public CircuitBreakerMetrics getMetrics() {
-    return metrics;
+  public JsonObject getMetrics() {
+    return metrics.toJson();
   }
 
   public CircuitBreakerOptions options() {

--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
@@ -921,6 +921,7 @@ public class CircuitBreakerImplTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidBucketSize() {
     CircuitBreakerOptions options = new CircuitBreakerOptions()
+      .setNotificationAddress(CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS)
       .setMetricsRollingBuckets(7);
     CircuitBreaker.create("test", vertx, options);
   }

--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerMetricsTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerMetricsTest.java
@@ -63,7 +63,7 @@ public class CircuitBreakerMetricsTest {
   @Test
   @Repeat(10)
   public void testWithSuccessfulCommands(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx);
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions());
     Async async = tc.async();
 
 
@@ -91,10 +91,15 @@ public class CircuitBreakerMetricsTest {
       });
   }
 
+  private CircuitBreakerOptions getOptions() {
+    return new CircuitBreakerOptions()
+      .setNotificationAddress(CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
+  }
+
   @Test
   @Repeat(10)
   public void testWithFailedCommands(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx);
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions());
     Async async = tc.async();
 
     Future<Void> command1 = breaker.execute(commandThatFails());
@@ -122,7 +127,7 @@ public class CircuitBreakerMetricsTest {
   @Test
   @Repeat(10)
   public void testWithCrashingCommands(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx);
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions());
     Async async = tc.async();
 
     Future<Void> command1 = breaker.execute(commandThatFails());
@@ -151,7 +156,7 @@ public class CircuitBreakerMetricsTest {
   @Test
   @Repeat(10)
   public void testWithTimeoutCommands(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, new CircuitBreakerOptions().setTimeout(100));
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions().setTimeout(100));
     Async async = tc.async();
 
     Future<Void> command1 = breaker.execute(commandThatFails());
@@ -181,7 +186,7 @@ public class CircuitBreakerMetricsTest {
   @Test
   @Repeat(10)
   public void testLatencyComputation(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx);
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions());
     Async async = tc.async();
 
 
@@ -212,8 +217,7 @@ public class CircuitBreakerMetricsTest {
   @Test
   @Repeat(100)
   public void testEviction(TestContext tc) {
-    breaker = CircuitBreaker.create("some-circuit-breaker", vertx,
-      new CircuitBreakerOptions().setMetricsRollingWindow(10));
+    breaker = CircuitBreaker.create("some-circuit-breaker", vertx, getOptions().setMetricsRollingWindow(10));
     Async async = tc.async();
 
 
@@ -253,7 +257,7 @@ public class CircuitBreakerMetricsTest {
   }
 
   private JsonObject metrics() {
-    return ((CircuitBreakerImpl) breaker).getMetrics().toJson();
+    return ((CircuitBreakerImpl) breaker).getMetrics();
   }
 
 }


### PR DESCRIPTION
It is not necessary to compute the metrics if they are not collected (by default, they are not).

Also, the dependency on HdrHistogram should be optional since metrics are not collected by default.