### PR TITLE
Adding some support for user defined async result failure testing.

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -114,7 +114,7 @@ Below is an example of exponential delay with jitter:
 == Failure Policy
 
 By default, the failure policy for {@link io.vertx.core.AsyncResult} is if the result is failed or not.
-You may also need to specify the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy(Predicate<io.vertx.core.AsyncResult>) }.
+You may also need to specify the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy }.
 This will let you specify the criteria in which an {@link io.vertx.core.AsyncResult} is treated as a failure by the circuit breaker.
 If you decide to override the failure policy, just be aware that it could allow failed results in the future provided in functions like `executeAndReport`.
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -114,7 +114,7 @@ Below is an example of exponential delay with jitter:
 == Failure Policy
 
 By default, the failure policy of a circuit breaker is to report a failure if the command doesn't complete successfully.
-You may also need to specify the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy }.
+Alternatively, you may configure the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy }.
 This will let you specify the criteria in which an {@link io.vertx.core.AsyncResult} is treated as a failure by the circuit breaker.
 If you decide to override the failure policy, just be aware that it could allow failed results in the future provided in functions like `executeAndReport`.
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -113,7 +113,7 @@ Below is an example of exponential delay with jitter:
 
 == Failure Policy
 
-By default, the failure policy for {@link io.vertx.core.AsyncResult} is if the result is failed or not.
+By default, the failure policy of a circuit breaker is to report a failure if the command doesn't complete successfully.
 You may also need to specify the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy }.
 This will let you specify the criteria in which an {@link io.vertx.core.AsyncResult} is treated as a failure by the circuit breaker.
 If you decide to override the failure policy, just be aware that it could allow failed results in the future provided in functions like `executeAndReport`.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -111,6 +111,20 @@ Below is an example of exponential delay with jitter:
 {@link examples.CircuitBreakerExamples#example8(io.vertx.core.Vertx)}
 ----
 
+== Failure Policy
+
+By default, the failure policy for {@link io.vertx.core.AsyncResult} is if the result is failed or not.
+You may also need to specify the failure policy of the circuit breaker with {@link  io.vertx.circuitbreaker.CircuitBreakerOptions#setAsyncResultFailurePolicy(Predicate<io.vertx.core.AsyncResult>) }.
+This will let you specify the criteria in which an {@link io.vertx.core.AsyncResult} is treated as a failure by the circuit breaker.
+If you decide to override the failure policy, just be aware that it could allow failed results in the future provided in functions like `executeAndReport`.
+
+Below is an example of using a custom defined failure policy.
+
+[source,$lang]
+----
+{@link examples.CircuitBreakerExamples#example9(io.vertx.core.Vertx)}
+----
+
 == Callbacks
 
 You can also configures callbacks invoked when the circuit is opened or closed:

--- a/src/main/java/examples/CircuitBreakerExamples.java
+++ b/src/main/java/examples/CircuitBreakerExamples.java
@@ -16,14 +16,14 @@
 
 package examples;
 
-import io.vertx.circuitbreaker.CircuitBreaker;
-import io.vertx.circuitbreaker.CircuitBreakerOptions;
-import io.vertx.circuitbreaker.HystrixMetricHandler;
-import io.vertx.circuitbreaker.RetryPolicy;
+import io.vertx.circuitbreaker.*;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Router;
 
@@ -227,6 +227,32 @@ public class CircuitBreakerExamples {
               }
             })).onComplete(promise);
       });
+  }
+
+  public void example9(Vertx vertx) {
+    CircuitBreaker breaker = CircuitBreaker.create("my-circuit-breaker", vertx,
+      new CircuitBreakerOptions().setAsyncResultFailurePolicy(asyncResult -> {
+        if(asyncResult.failed()) {
+          return true;
+        }
+
+        if(!(asyncResult.result() instanceof HttpClientResponse)) {
+          return true;
+        }
+
+        HttpClientResponse resp = (HttpClientResponse) asyncResult.result();
+        return resp.statusCode() != 200;
+      })
+    );
+
+    breaker.<AsyncResult<HttpClientResponse>>execute(
+      promise -> {
+        vertx.createHttpClient()
+          .request(HttpMethod.GET, 8080, "localhost", "/")
+          .compose(HttpClientRequest::send)
+          .onComplete(promise::complete);
+      });
+
   }
 
   public void enableNotifications(CircuitBreakerOptions options) {

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -90,7 +90,7 @@ public class CircuitBreakerOptions {
   /**
    * The default failure test, which is just true if the result is failed.
    */
-  public static final Predicate<AsyncResult> DEFAULT_ASYNC_FAILURE_POLICY = AsyncResult::failed;
+  public static final Predicate<AsyncResult> DEFAULT_ASYNC_RESULT_FAILURE_POLICY = AsyncResult::failed;
 
   /**
    * The operation timeout.
@@ -151,7 +151,7 @@ public class CircuitBreakerOptions {
   /**
    *  The way we determine if an asynchronous result is indeed a failure.
    */
-  private Predicate<AsyncResult> asyncFailurePolicy = DEFAULT_ASYNC_FAILURE_POLICY;
+  private Predicate<AsyncResult> asyncResultFailurePolicy = DEFAULT_ASYNC_RESULT_FAILURE_POLICY;
 
   /**
    * Creates a new instance of {@link CircuitBreakerOptions} using the default values.
@@ -177,7 +177,7 @@ public class CircuitBreakerOptions {
     this.metricsRollingBuckets = other.metricsRollingBuckets;
     this.metricsRollingWindow = other.metricsRollingWindow;
     this.failuresRollingWindow = other.failuresRollingWindow;
-    this.asyncFailurePolicy = other.asyncFailurePolicy;
+    this.asyncResultFailurePolicy = other.asyncResultFailurePolicy;
   }
 
   /**
@@ -405,18 +405,18 @@ public class CircuitBreakerOptions {
     return this;
   }
 
-  public Predicate<AsyncResult> getAsyncFailurePolicy() {
-    return asyncFailurePolicy;
+  public Predicate<AsyncResult> getAsyncResultFailurePolicy() {
+    return asyncResultFailurePolicy;
   }
 
   /**
    * Configures the failure policy of an AsyncResult. This will allow you to control if an event failed or passed.
    *
-   * @param asyncFailurePolicy The failure policy of the async result event.
+   * @param asyncResultFailurePolicy The failure policy of the async result event.
    * @return the current {@link CircuitBreakerOptions} instance
    */
-  public CircuitBreakerOptions setAsyncFailurePolicy(Predicate<AsyncResult> asyncFailurePolicy) {
-    this.asyncFailurePolicy = asyncFailurePolicy;
+  public CircuitBreakerOptions setAsyncResultFailurePolicy(Predicate<AsyncResult> asyncResultFailurePolicy) {
+    this.asyncResultFailurePolicy = asyncResultFailurePolicy;
     return this;
   }
 }

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -149,7 +149,7 @@ public class CircuitBreakerOptions {
 
 
   /**
-   *  The way we determine if an asynchronous result is indeed a failure.
+   *  The way we determine if an {@link AsyncResult} is a failure.
    */
   private Predicate<AsyncResult> asyncResultFailurePolicy = DEFAULT_ASYNC_RESULT_FAILURE_POLICY;
 
@@ -405,12 +405,16 @@ public class CircuitBreakerOptions {
     return this;
   }
 
+  /**
+   * @return the failure policy used for determining if an {@link AsyncResult} is a failure.
+   */
   public Predicate<AsyncResult> getAsyncResultFailurePolicy() {
     return asyncResultFailurePolicy;
   }
 
   /**
-   * Configures the failure policy of an AsyncResult. This will allow you to control if an event failed or passed.
+   * Configures the failure policy of an {@link AsyncResult}.
+   * This will allow you to control if an event failed or passed.
    *
    * @param asyncResultFailurePolicy The failure policy of the async result event.
    * @return the current {@link CircuitBreakerOptions} instance

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -90,7 +90,7 @@ public class CircuitBreakerOptions {
   /**
    * The default failure test, which is just true if the result is failed.
    */
-  public static final Predicate<AsyncResult> DEFAULT_ASYNC_RESULT_FAILURE_TEST = AsyncResult::failed;
+  public static final Predicate<AsyncResult> DEFAULT_ASYNC_FAILURE_POLICY = AsyncResult::failed;
 
   /**
    * The operation timeout.
@@ -149,9 +149,9 @@ public class CircuitBreakerOptions {
 
 
   /**
-   * The way we determine if a future is indeed a failure.
+   *  The way we determine if an asynchronous result is indeed a failure.
    */
-  private Predicate<AsyncResult> asyncResultTest = DEFAULT_ASYNC_RESULT_FAILURE_TEST;
+  private Predicate<AsyncResult> asyncFailurePolicy = DEFAULT_ASYNC_FAILURE_POLICY;
 
   /**
    * Creates a new instance of {@link CircuitBreakerOptions} using the default values.
@@ -177,7 +177,7 @@ public class CircuitBreakerOptions {
     this.metricsRollingBuckets = other.metricsRollingBuckets;
     this.metricsRollingWindow = other.metricsRollingWindow;
     this.failuresRollingWindow = other.failuresRollingWindow;
-    this.asyncResultTest = other.asyncResultTest;
+    this.asyncFailurePolicy = other.asyncFailurePolicy;
   }
 
   /**
@@ -405,12 +405,18 @@ public class CircuitBreakerOptions {
     return this;
   }
 
-  public Predicate<AsyncResult> getAsyncFailureResultTest() {
-    return asyncResultTest;
+  public Predicate<AsyncResult> getAsyncFailurePolicy() {
+    return asyncFailurePolicy;
   }
 
-  public CircuitBreakerOptions setAsyncFailureResultTest(Predicate<AsyncResult> asyncResultTest) {
-    this.asyncResultTest = asyncResultTest;
+  /**
+   * Configures the failure policy of an AsyncResult. This will allow you to control if an event failed or passed.
+   *
+   * @param asyncFailurePolicy The failure policy of the async result event.
+   * @return the current {@link CircuitBreakerOptions} instance
+   */
+  public CircuitBreakerOptions setAsyncFailurePolicy(Predicate<AsyncResult> asyncFailurePolicy) {
+    this.asyncFailurePolicy = asyncFailurePolicy;
     return this;
   }
 }

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerOptions.java
@@ -18,7 +18,10 @@ package io.vertx.circuitbreaker;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.json.JsonObject;
+
+import java.util.function.Predicate;
 
 /**
  * Circuit breaker configuration options. All time are given in milliseconds.
@@ -85,6 +88,11 @@ public class CircuitBreakerOptions {
   private static final int DEFAULT_FAILURES_ROLLING_WINDOW = 10000;
 
   /**
+   * The default failure test, which is just true if the result is failed.
+   */
+  public static final Predicate<AsyncResult> DEFAULT_ASYNC_RESULT_FAILURE_TEST = AsyncResult::failed;
+
+  /**
    * The operation timeout.
    */
   private long timeout = DEFAULT_TIMEOUT;
@@ -139,6 +147,12 @@ public class CircuitBreakerOptions {
    */
   private long failuresRollingWindow = DEFAULT_FAILURES_ROLLING_WINDOW;
 
+
+  /**
+   * The way we determine if a future is indeed a failure.
+   */
+  private Predicate<AsyncResult> asyncResultTest = DEFAULT_ASYNC_RESULT_FAILURE_TEST;
+
   /**
    * Creates a new instance of {@link CircuitBreakerOptions} using the default values.
    */
@@ -163,6 +177,7 @@ public class CircuitBreakerOptions {
     this.metricsRollingBuckets = other.metricsRollingBuckets;
     this.metricsRollingWindow = other.metricsRollingWindow;
     this.failuresRollingWindow = other.failuresRollingWindow;
+    this.asyncResultTest = other.asyncResultTest;
   }
 
   /**
@@ -387,6 +402,15 @@ public class CircuitBreakerOptions {
    */
   public CircuitBreakerOptions setMaxRetries(int maxRetries) {
     this.maxRetries = maxRetries;
+    return this;
+  }
+
+  public Predicate<AsyncResult> getAsyncFailureResultTest() {
+    return asyncResultTest;
+  }
+
+  public CircuitBreakerOptions setAsyncFailureResultTest(Predicate<AsyncResult> asyncResultTest) {
+    this.asyncResultTest = asyncResultTest;
     return this;
   }
 }

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -228,7 +228,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
     if (currentState == CircuitBreakerState.CLOSED) {
       operationResult.future().onComplete(event -> {
         context.runOnContext(v -> {
-          if (event.failed()) {
+          if (options.getAsyncFailureResultTest().test(event)) {
             incrementFailures();
             if (call != null) {
               call.failed();
@@ -243,7 +243,13 @@ public class CircuitBreakerImpl implements CircuitBreaker {
               call.complete();
             }
             reset();
-            userFuture.complete(event.result());
+            //The event may pass due to a user given predicate. We still want to push up the failure for the user
+            //to do any work
+            if(event.failed()) {
+              userFuture.fail(event.cause());
+            } else {
+              userFuture.complete(event.result());
+            }
           }
           // Else the operation has been canceled because of a time out.
         });
@@ -264,7 +270,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
       if (passed.incrementAndGet() == 1) {
         operationResult.future().onComplete(event -> {
           context.runOnContext(v -> {
-            if (event.failed()) {
+            if (options.getAsyncFailureResultTest().test(event)) {
               open();
               if (call != null) {
                 call.failed();
@@ -279,7 +285,13 @@ public class CircuitBreakerImpl implements CircuitBreaker {
                 call.complete();
               }
               reset();
-              userFuture.complete(event.result());
+              //The event may pass due to a user given predicate. We still want to push up the failure for the user
+              //to do any work
+              if(event.failed()) {
+                userFuture.fail(event.cause());
+              } else {
+                userFuture.complete(event.result());
+              }
             }
           });
         });

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -228,7 +228,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
     if (currentState == CircuitBreakerState.CLOSED) {
       operationResult.future().onComplete(event -> {
         context.runOnContext(v -> {
-          if (options.getAsyncFailurePolicy().test(event)) {
+          if (options.getAsyncResultFailurePolicy().test(event)) {
             incrementFailures();
             if (call != null) {
               call.failed();
@@ -266,7 +266,7 @@ public class CircuitBreakerImpl implements CircuitBreaker {
       if (passed.incrementAndGet() == 1) {
         operationResult.future().onComplete(event -> {
           context.runOnContext(v -> {
-            if (options.getAsyncFailurePolicy().test(event)) {
+            if (options.getAsyncResultFailurePolicy().test(event)) {
               open();
               if (call != null) {
                 call.failed();

--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
@@ -97,7 +97,7 @@ public class CircuitBreakerImplTest {
   @Test
   @Repeat(5)
   public void testWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncResultFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -146,7 +146,7 @@ public class CircuitBreakerImplTest {
   @Test
   @Repeat(5)
   public void testWithUserFutureWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncResultFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -193,7 +193,7 @@ public class CircuitBreakerImplTest {
 
   @Test
   public void testAsynchronousWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncResultFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -242,7 +242,7 @@ public class CircuitBreakerImplTest {
 
   @Test
   public void testAsynchronousWithUserFutureAndWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncResultFailurePolicy(ar -> {
       if(ar.failed() && ar.cause() instanceof ClassNotFoundException) {
         return true;
       }
@@ -466,7 +466,7 @@ public class CircuitBreakerImplTest {
   public void testFailureOnAsynchronousCodeWithCustomPredicate() {
     AtomicBoolean called = new AtomicBoolean(false);
     AtomicReference<String> result = new AtomicReference<>();
-    CircuitBreakerOptions options = new CircuitBreakerOptions().setResetTimeout(-1).setAsyncFailurePolicy(ar -> {
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setResetTimeout(-1).setAsyncResultFailurePolicy(ar -> {
       if(ar.failed() && ar.cause() instanceof NoStackTraceThrowable) {
         return true;
       }

--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
@@ -97,7 +97,7 @@ public class CircuitBreakerImplTest {
   @Test
   @Repeat(5)
   public void testWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailureResultTest(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -146,7 +146,7 @@ public class CircuitBreakerImplTest {
   @Test
   @Repeat(5)
   public void testWithUserFutureWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailureResultTest(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -193,7 +193,7 @@ public class CircuitBreakerImplTest {
 
   @Test
   public void testAsynchronousWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailureResultTest(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
       if(ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable)) {
         return true;
       }
@@ -242,7 +242,7 @@ public class CircuitBreakerImplTest {
 
   @Test
   public void testAsynchronousWithUserFutureAndWithCustomPredicateOk() {
-    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailureResultTest(ar -> {
+    breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions().setAsyncFailurePolicy(ar -> {
       if(ar.failed() && ar.cause() instanceof ClassNotFoundException) {
         return true;
       }
@@ -466,7 +466,7 @@ public class CircuitBreakerImplTest {
   public void testFailureOnAsynchronousCodeWithCustomPredicate() {
     AtomicBoolean called = new AtomicBoolean(false);
     AtomicReference<String> result = new AtomicReference<>();
-    CircuitBreakerOptions options = new CircuitBreakerOptions().setResetTimeout(-1).setAsyncFailureResultTest(ar -> {
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setResetTimeout(-1).setAsyncFailurePolicy(ar -> {
       if(ar.failed() && ar.cause() instanceof NoStackTraceThrowable) {
         return true;
       }


### PR DESCRIPTION
Motivation:

As described in https://github.com/vert-x3/vertx-circuit-breaker/issues/65, it would be nicer to have an exposed API to allow users to more flexibly determine if an ```AsyncResult``` should be treated as a failure by the circuit breaker. Currently the implementation is not very flexible and only checks if the ```AsyncResult``` has failed.  Sometimes though, the failures could be legitimate and should not increase the circuit breaker.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
