### PR TITLE
Rework Failure Policy API

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -111,9 +111,23 @@ Below is an example of exponential delay with jitter:
 {@link examples.CircuitBreakerExamples#example8(io.vertx.core.Vertx)}
 ----
 
+== Failure Policy
+
+By default, the failure policy of a circuit breaker is to report a failure if the command doesn't complete successfully.
+Alternatively, you may configure the failure policy of the circuit breaker with {@link io.vertx.circuitbreaker.CircuitBreaker#failurePolicy}.
+This will let you specify the criteria in which an {@link io.vertx.core.AsyncResult} is treated as a failure by the circuit breaker.
+If you decide to override the failure policy, just be aware that it could allow failed results in the future provided in functions like `executeAndReport`.
+
+Below is an example of using a custom defined failure policy.
+
+[source,$lang]
+----
+{@link examples.CircuitBreakerExamples#example9(io.vertx.core.Vertx)}
+----
+
 == Callbacks
 
-You can also configures callbacks invoked when the circuit is opened or closed:
+You can also configure callbacks invoked when the circuit is opened or closed:
 
 [source,$lang]
 ----

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreaker.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreaker.java
@@ -20,11 +20,7 @@ import io.vertx.circuitbreaker.impl.CircuitBreakerImpl;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 
 import java.util.function.Function;
 
@@ -202,6 +198,17 @@ public interface CircuitBreaker {
    */
   @Fluent
   <T> CircuitBreaker fallback(Function<Throwable, T> handler);
+
+  /**
+   * Configures the failure policy for this circuit-breaker.
+   *
+   * @return the current {@link CircuitBreaker}
+   * @see FailurePolicy
+   */
+  @Fluent
+  default <T> CircuitBreaker failurePolicy(FailurePolicy<T> failurePolicy) {
+    return this;
+  }
 
   /**
    * Resets the circuit breaker state (number of failure set to 0 and state set to closed).

--- a/src/main/java/io/vertx/circuitbreaker/FailurePolicy.java
+++ b/src/main/java/io/vertx/circuitbreaker/FailurePolicy.java
@@ -1,0 +1,35 @@
+package io.vertx.circuitbreaker;
+
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+
+import java.util.function.Predicate;
+
+/**
+ * A failure policy for the {@link CircuitBreaker}.
+ * <p>
+ * The default policy is to consider an asynchronous result as a failure if {@link AsyncResult#failed()} returns {@code true}.
+ * Nevertheless, sometimes this is not good enough. For example, an HTTP Client could return a response, but with an unexpected status code.
+ * <p>
+ * In this case, a custom failure policy can be configured with {@link CircuitBreaker#failurePolicy(FailurePolicy)}.
+ */
+@VertxGen
+public interface FailurePolicy<T> extends Predicate<Future<T>> {
+
+  /**
+   * The default policy, which considers an asynchronous result as a failure if {@link AsyncResult#failed()} returns {@code true}.
+   */
+  static <U> FailurePolicy<U> defaultPolicy() {
+    return AsyncResult::failed;
+  }
+
+  /**
+   * Invoked by the {@link CircuitBreaker} when an operation completes.
+   *
+   * @param future a completed future
+   * @return {@code true} if the asynchronous result should be considered as a failure, {@code false} otherwise
+   */
+  @Override
+  boolean test(Future<T> future);
+}

--- a/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/impl/CircuitBreakerImplTest.java
@@ -18,6 +18,7 @@ package io.vertx.circuitbreaker.impl;
 
 import io.vertx.circuitbreaker.*;
 import io.vertx.core.*;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.Repeat;
@@ -95,6 +96,29 @@ public class CircuitBreakerImplTest {
 
   @Test
   @Repeat(5)
+  public void testWithCustomPredicateOk() {
+    breaker = CircuitBreaker.create("test", vertx).failurePolicy(ar -> {
+      return ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable);
+    });
+
+    assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
+
+    AtomicBoolean operationCalled = new AtomicBoolean();
+    AtomicReference<String> completionCalled = new AtomicReference<>();
+    breaker.<String>execute(fut -> {
+      operationCalled.set(true);
+      fut.fail("some fake exception");
+    }).onComplete(ar -> {
+      completionCalled.set(ar.cause().getMessage());
+      assertThat(ar.failed()).isTrue();
+    });
+
+    await().until(operationCalled::get);
+    await().until(() -> completionCalled.get().equalsIgnoreCase("some fake exception"));
+  }
+
+  @Test
+  @Repeat(5)
   public void testWithUserFutureOk() {
     breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions());
     assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
@@ -116,6 +140,32 @@ public class CircuitBreakerImplTest {
   }
 
   @Test
+  @Repeat(5)
+  public void testWithUserFutureWithCustomPredicateOk() {
+    breaker = CircuitBreaker.create("test", vertx).failurePolicy(ar -> {
+      return ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable);
+    });
+    assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
+
+    AtomicBoolean operationCalled = new AtomicBoolean();
+    AtomicReference<String> completionCalled = new AtomicReference<>();
+
+    Promise<String> userFuture = Promise.promise();
+    userFuture.future().onComplete(ar -> {
+      completionCalled.set(ar.cause().getMessage());
+      assertThat(ar.failed()).isTrue();
+    });
+
+    breaker.executeAndReport(userFuture, fut -> {
+      operationCalled.set(true);
+      fut.fail("some custom exception");
+    });
+
+    await().until(operationCalled::get);
+    await().until(() -> completionCalled.get().equalsIgnoreCase("some custom exception"));
+  }
+
+  @Test
   public void testAsynchronousOk() {
     breaker = CircuitBreaker.create("test", vertx, new CircuitBreakerOptions());
     assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
@@ -131,6 +181,30 @@ public class CircuitBreakerImplTest {
 
     await().until(called::get);
     await().untilAtomic(result, is("hello"));
+  }
+
+  @Test
+  public void testAsynchronousWithCustomPredicateOk() {
+    breaker = CircuitBreaker.create("test", vertx).failurePolicy(ar -> {
+      return ar.failed() && !(ar.cause() instanceof NoStackTraceThrowable);
+    });
+    assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
+
+    AtomicBoolean called = new AtomicBoolean();
+    AtomicReference<String> result = new AtomicReference<>();
+    breaker.<String>execute(future ->
+      vertx.setTimer(100, l -> {
+        called.set(true);
+        future.fail("some custom exception");
+      })
+    ).onComplete(ar -> {
+      result.set(ar.cause().getMessage());
+      assertThat(ar.failed()).isTrue();
+    });
+    ;
+
+    await().until(called::get);
+    await().untilAtomic(result, is("some custom exception"));
   }
 
   @Test
@@ -153,6 +227,34 @@ public class CircuitBreakerImplTest {
 
     await().until(called::get);
     await().untilAtomic(result, is("hello"));
+  }
+
+  @Test
+  public void testAsynchronousWithUserFutureAndWithCustomPredicateOk() {
+    breaker = CircuitBreaker.create("test", vertx).failurePolicy(ar -> {
+      return ar.failed() && ar.cause() instanceof ClassNotFoundException;
+    });
+    assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
+
+    AtomicBoolean called = new AtomicBoolean();
+    AtomicReference<String> result = new AtomicReference<>();
+
+    Promise<String> userFuture = Promise.promise();
+    userFuture.future().onComplete(ar -> {
+      result.set(ar.cause().getMessage());
+      assertThat(ar.failed()).isTrue();
+    });
+    ;
+
+    breaker.executeAndReport(userFuture, future ->
+      vertx.setTimer(100, l -> {
+        called.set(true);
+        future.fail(new NullPointerException("some custom exception"));
+      })
+    );
+
+    await().until(called::get);
+    await().untilAtomic(result, is("some custom exception"));
   }
 
   @Test
@@ -227,7 +329,7 @@ public class CircuitBreakerImplTest {
       .setMaxFailures(1));
 
     Handler<Promise<Void>> fail = p -> p.fail("fail");
-    Handler<Promise<Void>> success = p -> p.complete();
+    Handler<Promise<Void>> success = Promise::complete;
 
     ctx.runOnContext(v -> {
       breaker.execute(fail);
@@ -341,6 +443,44 @@ public class CircuitBreakerImplTest {
         spy.set(true);
       }))
       .onComplete(ar -> result.set(ar.result()));
+    await().untilAtomic(called, is(true));
+    assertThat(spy.get()).isEqualTo(false);
+    assertThat(result.get()).isEqualTo("fallback");
+  }
+
+  @Test
+  public void testFailureOnAsynchronousCodeWithCustomPredicate() {
+    AtomicBoolean called = new AtomicBoolean(false);
+    AtomicReference<String> result = new AtomicReference<>();
+    CircuitBreakerOptions options = new CircuitBreakerOptions().setResetTimeout(-1);
+    breaker = CircuitBreaker.create("test", vertx, options)
+      .fallback(v -> {
+        called.set(true);
+        return "fallback";
+      })
+      .failurePolicy(ar -> {
+        return ar.failed() && ar.cause() instanceof NoStackTraceThrowable;
+      });
+    assertThat(breaker.state()).isEqualTo(CircuitBreakerState.CLOSED);
+
+    for (int i = 0; i < options.getMaxFailures(); i++) {
+      breaker.<String>execute(
+        future -> vertx.setTimer(100, l -> future.fail("expected failure"))
+      ).onComplete(ar -> result.set(ar.result()));
+    }
+    await().until(() -> breaker.state() == CircuitBreakerState.OPEN);
+    assertThat(called.get()).isFalse();
+
+    AtomicBoolean spy = new AtomicBoolean();
+    breaker.<String>execute(
+        future -> vertx.setTimer(100, l -> {
+          future.fail("expected failure");
+          spy.set(true);
+        }))
+      .onComplete(ar -> {
+        result.set(ar.result());
+      });
+    ;
     await().untilAtomic(called, is(true));
     assertThat(spy.get()).isEqualTo(false);
     assertThat(result.get()).isEqualTo("fallback");


### PR DESCRIPTION
Follows-up on #72
Related to https://github.com/vert-x3/vertx-lang-kotlin/issues/262

The previous design was not compatible with codegen and Kotlin. In this commit, the failure policy is a parameter of the circuit breaker, like the fallback function.