### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -20,7 +20,6 @@ import io.vertx.circuitbreaker.*;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.internal.ContextInternal;
-import io.vertx.core.internal.PromiseInternal;
 import io.vertx.core.json.JsonObject;
 
 import java.util.LinkedHashMap;

--- a/src/test/java/io/vertx/circuitbreaker/tests/impl/CircuitBreakerWithHTTPTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/tests/impl/CircuitBreakerWithHTTPTest.java
@@ -31,7 +31,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.