### PR TITLE
add CircuitBreakerBuilder, make handlers set on construction immutable

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -144,6 +144,19 @@ You can also configure callbacks invoked when the circuit breaker is opened or c
 You can also be notified when the circuit breaker moves to the half-open state, in an attempt to reset. You can register
 such a callback with {@link io.vertx.circuitbreaker.CircuitBreaker#halfOpenHandler(io.vertx.core.Handler)}.
 
+Alternatively, you can assemble a circuit breaker with the builder {@link io.vertx.circuitbreaker.CircuitBreaker#builder}
+API. Handlers configured through the builder are baked in as soon as the circuit breaker is built: calling
+{@link io.vertx.circuitbreaker.CircuitBreaker#openHandler(io.vertx.core.Handler)},
+{@link io.vertx.circuitbreaker.CircuitBreaker#halfOpenHandler(io.vertx.core.Handler)} or
+{@link io.vertx.circuitbreaker.CircuitBreaker#closeHandler(io.vertx.core.Handler)} again for a handler set this way
+throws an `IllegalStateException`, so callbacks configured up front cannot be silently replaced later. Handlers left
+unset in the builder remain freely settable afterwards.
+
+[source,$lang]
+----
+{@link examples.CircuitBreakerExamples#example10(io.vertx.core.Vertx)}
+----
+
 == Event bus notification
 
 Every time the circuit breaker state changes, an event can be published on the event bus.

--- a/src/main/java/examples/CircuitBreakerExamples.java
+++ b/src/main/java/examples/CircuitBreakerExamples.java
@@ -196,6 +196,32 @@ public class CircuitBreakerExamples {
     });
   }
 
+  public void example10(Vertx vertx) {
+    CircuitBreaker breaker = CircuitBreaker.builder("my-circuit-breaker", vertx)
+      .with(new CircuitBreakerOptions().setMaxFailures(5).setTimeout(2000))
+      .openHandler(v -> {
+        System.out.println("Circuit breaker opened");
+      })
+      .closeHandler(v -> {
+        System.out.println("Circuit breaker closed");
+      })
+      .build();
+
+    breaker.<String>execute(promise -> {
+      vertx.createHttpClient().request(HttpMethod.GET, 8080, "localhost", "/")
+        .compose(req -> req
+          .send()
+          .compose(resp -> {
+            if (resp.statusCode() != 200) {
+              return Future.failedFuture("HTTP error");
+            } else {
+              return resp.body().map(Buffer::toString);
+            }
+          }))
+        .onComplete(promise);
+    });
+  }
+
   public void enableNotifications(CircuitBreakerOptions options) {
     options.setNotificationAddress(CircuitBreakerOptions.DEFAULT_NOTIFICATION_ADDRESS);
   }

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreaker.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreaker.java
@@ -16,6 +16,7 @@
 
 package io.vertx.circuitbreaker;
 
+import io.vertx.circuitbreaker.impl.CircuitBreakerBuilderImpl;
 import io.vertx.circuitbreaker.impl.CircuitBreakerImpl;
 import io.vertx.codegen.annotations.CacheReturn;
 import io.vertx.codegen.annotations.Fluent;
@@ -60,6 +61,20 @@ public interface CircuitBreaker {
   }
 
   /**
+   * Creates a new {@link CircuitBreakerBuilder} to configure and build a {@link CircuitBreaker}.
+   * <p>
+   * Unlike {@link #create(String, Vertx, CircuitBreakerOptions)}, handlers configured through the builder cannot be
+   * changed after the circuit breaker is built; see {@link CircuitBreakerBuilder}.
+   *
+   * @param name  the name
+   * @param vertx the Vert.x instance
+   * @return the created builder
+   */
+  static CircuitBreakerBuilder builder(String name, Vertx vertx) {
+    return new CircuitBreakerBuilderImpl(name, vertx);
+  }
+
+  /**
    * Closes the circuit breaker. It stops sending events on its state on the event bus.
    * <p>
    * This method is not related to the {@code closed} state of the circuit breaker. To move the circuit breaker to the
@@ -73,6 +88,8 @@ public interface CircuitBreaker {
    *
    * @param handler the handler, must not be {@code null}
    * @return this {@link CircuitBreaker}
+   * @throws IllegalStateException if this circuit breaker was built with {@link CircuitBreakerBuilder} and an open
+   *                                handler was already supplied to the builder
    */
   @Fluent
   CircuitBreaker openHandler(Handler<Void> handler);
@@ -82,6 +99,8 @@ public interface CircuitBreaker {
    *
    * @param handler the handler, must not be {@code null}
    * @return this {@link CircuitBreaker}
+   * @throws IllegalStateException if this circuit breaker was built with {@link CircuitBreakerBuilder} and a
+   *                                half-open handler was already supplied to the builder
    */
   @Fluent
   CircuitBreaker halfOpenHandler(Handler<Void> handler);
@@ -91,6 +110,8 @@ public interface CircuitBreaker {
    *
    * @param handler the handler, must not be {@code null}
    * @return this {@link CircuitBreaker}
+   * @throws IllegalStateException if this circuit breaker was built with {@link CircuitBreakerBuilder} and a close
+   *                                handler was already supplied to the builder
    */
   @Fluent
   CircuitBreaker closeHandler(Handler<Void> handler);

--- a/src/main/java/io/vertx/circuitbreaker/CircuitBreakerBuilder.java
+++ b/src/main/java/io/vertx/circuitbreaker/CircuitBreakerBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.circuitbreaker;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Handler;
+
+import java.util.function.Function;
+
+/**
+ * A builder for {@link CircuitBreaker}.
+ * <p>
+ * Unlike {@link CircuitBreaker#openHandler(Handler)}, {@link CircuitBreaker#halfOpenHandler(Handler)} and
+ * {@link CircuitBreaker#closeHandler(Handler)}, the handlers configured through this builder are baked in as
+ * immutable when {@link #build()} is called: calling the corresponding mutator method again on the built circuit
+ * breaker throws an {@link IllegalStateException}.
+ */
+@VertxGen
+public interface CircuitBreakerBuilder {
+
+  /**
+   * Configure the circuit breaker options.
+   *
+   * @param options the configuration options
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CircuitBreakerBuilder with(CircuitBreakerOptions options);
+
+  /**
+   * Set the handler invoked when the circuit breaker state switches to open.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CircuitBreakerBuilder openHandler(Handler<Void> handler);
+
+  /**
+   * Set the handler invoked when the circuit breaker state switches to half-open.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CircuitBreakerBuilder halfOpenHandler(Handler<Void> handler);
+
+  /**
+   * Set the handler invoked when the circuit breaker state switches to closed.
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CircuitBreakerBuilder closeHandler(Handler<Void> handler);
+
+  /**
+   * Set the default fallback function, see {@link CircuitBreaker#fallback(Function)}.
+   *
+   * @param handler the fallback function
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  <T> CircuitBreakerBuilder fallback(Function<Throwable, T> handler);
+
+  /**
+   * Set the failure policy, see {@link CircuitBreaker#failurePolicy(FailurePolicy)}.
+   *
+   * @param failurePolicy the failure policy
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  <T> CircuitBreakerBuilder failurePolicy(FailurePolicy<T> failurePolicy);
+
+  /**
+   * Set the retry policy, see {@link CircuitBreaker#retryPolicy(RetryPolicy)}.
+   *
+   * @param retryPolicy the retry policy
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  CircuitBreakerBuilder retryPolicy(RetryPolicy retryPolicy);
+
+  /**
+   * Build and return the circuit breaker.
+   *
+   * @return the circuit breaker as configured by this builder
+   */
+  CircuitBreaker build();
+}

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerBuilderImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerBuilderImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.circuitbreaker.impl;
+
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerBuilder;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.FailurePolicy;
+import io.vertx.circuitbreaker.RetryPolicy;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class CircuitBreakerBuilderImpl implements CircuitBreakerBuilder {
+
+  private final String name;
+  private final Vertx vertx;
+  private CircuitBreakerOptions options;
+  private Handler<Void> openHandler;
+  private Handler<Void> halfOpenHandler;
+  private Handler<Void> closeHandler;
+  private Function fallback;
+  private FailurePolicy failurePolicy;
+  private RetryPolicy retryPolicy;
+
+  public CircuitBreakerBuilderImpl(String name, Vertx vertx) {
+    this.name = Objects.requireNonNull(name);
+    this.vertx = Objects.requireNonNull(vertx);
+  }
+
+  @Override
+  public CircuitBreakerBuilder with(CircuitBreakerOptions options) {
+    this.options = options;
+    return this;
+  }
+
+  @Override
+  public CircuitBreakerBuilder openHandler(Handler<Void> handler) {
+    this.openHandler = Objects.requireNonNull(handler);
+    return this;
+  }
+
+  @Override
+  public CircuitBreakerBuilder halfOpenHandler(Handler<Void> handler) {
+    this.halfOpenHandler = Objects.requireNonNull(handler);
+    return this;
+  }
+
+  @Override
+  public CircuitBreakerBuilder closeHandler(Handler<Void> handler) {
+    this.closeHandler = Objects.requireNonNull(handler);
+    return this;
+  }
+
+  @Override
+  public <T> CircuitBreakerBuilder fallback(Function<Throwable, T> handler) {
+    this.fallback = Objects.requireNonNull(handler);
+    return this;
+  }
+
+  @Override
+  public <T> CircuitBreakerBuilder failurePolicy(FailurePolicy<T> failurePolicy) {
+    this.failurePolicy = Objects.requireNonNull(failurePolicy);
+    return this;
+  }
+
+  @Override
+  public CircuitBreakerBuilder retryPolicy(RetryPolicy retryPolicy) {
+    this.retryPolicy = Objects.requireNonNull(retryPolicy);
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public CircuitBreaker build() {
+    CircuitBreakerImpl impl = new CircuitBreakerImpl(name, vertx, options, openHandler, halfOpenHandler, closeHandler);
+    if (fallback != null) {
+      impl.fallback(fallback);
+    }
+    if (failurePolicy != null) {
+      impl.failurePolicy(failurePolicy);
+    }
+    if (retryPolicy != null) {
+      impl.retryPolicy(retryPolicy);
+    }
+    return impl;
+  }
+}

--- a/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
+++ b/src/main/java/io/vertx/circuitbreaker/impl/CircuitBreakerImpl.java
@@ -44,9 +44,9 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   private final String name;
   private final long periodicUpdateTask;
 
-  private Handler<Void> openHandler = NOOP;
-  private Handler<Void> halfOpenHandler = NOOP;
-  private Handler<Void> closeHandler = NOOP;
+  private final Handler<Void> openHandler;
+  private final Handler<Void> halfOpenHandler;
+  private final Handler<Void> closeHandler;
   private Function fallback = null;
   private FailurePolicy failurePolicy = FailurePolicy.defaultPolicy();
 
@@ -59,6 +59,19 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   private RetryPolicy retryPolicy = (failure, retryCount) -> 0L;
 
   public CircuitBreakerImpl(String name, Vertx vertx, CircuitBreakerOptions options) {
+    this(name, vertx, options, null, null, null);
+  }
+
+  /**
+   * Creates a new instance of {@link CircuitBreakerImpl} with handlers supplied by a {@link CircuitBreakerBuilder}.
+   * <p>
+   * A non-{@code null} handler is baked in as immutable: the corresponding mutable setter
+   * ({@link #openHandler(Handler)}, {@link #halfOpenHandler(Handler)} or {@link #closeHandler(Handler)}) then throws
+   * {@link IllegalStateException} instead of replacing it. A {@code null} handler keeps the existing mutable
+   * behavior, backed by a {@link DelegatingHandler}.
+   */
+  CircuitBreakerImpl(String name, Vertx vertx, CircuitBreakerOptions options,
+                     Handler<Void> openHandler, Handler<Void> halfOpenHandler, Handler<Void> closeHandler) {
     Objects.requireNonNull(name);
     Objects.requireNonNull(vertx);
     this.vertx = vertx;
@@ -69,6 +82,10 @@ public class CircuitBreakerImpl implements CircuitBreaker {
     } else {
       this.options = new CircuitBreakerOptions(options);
     }
+
+    this.openHandler = openHandler != null ? openHandler : new DelegatingHandler<>(NOOP);
+    this.halfOpenHandler = halfOpenHandler != null ? halfOpenHandler : new DelegatingHandler<>(NOOP);
+    this.closeHandler = closeHandler != null ? closeHandler : new DelegatingHandler<>(NOOP);
 
     this.rollingFailures = new RollingCounter(this.options.getFailuresRollingWindow() / 1000, TimeUnit.SECONDS);
 
@@ -98,24 +115,28 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   }
 
   @Override
-  public synchronized CircuitBreaker openHandler(Handler<Void> handler) {
-    Objects.requireNonNull(handler);
-    openHandler = handler;
+  public CircuitBreaker openHandler(Handler<Void> handler) {
+    setDelegate(openHandler, handler, "openHandler");
     return this;
   }
 
   @Override
-  public synchronized CircuitBreaker halfOpenHandler(Handler<Void> handler) {
-    Objects.requireNonNull(handler);
-    halfOpenHandler = handler;
+  public CircuitBreaker halfOpenHandler(Handler<Void> handler) {
+    setDelegate(halfOpenHandler, handler, "halfOpenHandler");
     return this;
   }
 
   @Override
-  public synchronized CircuitBreaker closeHandler(Handler<Void> handler) {
-    Objects.requireNonNull(handler);
-    closeHandler = handler;
+  public CircuitBreaker closeHandler(Handler<Void> handler) {
+    setDelegate(closeHandler, handler, "closeHandler");
     return this;
+  }
+
+  private static void setDelegate(Handler<Void> field, Handler<Void> handler, String setterName) {
+    if (!(field instanceof DelegatingHandler)) {
+      throw new IllegalStateException(setterName + " was set through CircuitBreakerBuilder and cannot be changed");
+    }
+    ((DelegatingHandler<Void>) field).setDelegate(handler);
   }
 
   @Override
@@ -452,6 +473,28 @@ public class CircuitBreakerImpl implements CircuitBreaker {
   public CircuitBreaker retryPolicy(RetryPolicy retryPolicy) {
     this.retryPolicy = retryPolicy;
     return this;
+  }
+
+  /**
+   * Wraps a mutable {@code delegate}, so that {@link #openHandler}, {@link #halfOpenHandler} and
+   * {@link #closeHandler} can stay {@code final} while still supporting the legacy mutable setters.
+   */
+  private static class DelegatingHandler<T> implements Handler<T> {
+
+    private volatile Handler<T> delegate;
+
+    private DelegatingHandler(Handler<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    private void setDelegate(Handler<T> delegate) {
+      this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public void handle(T event) {
+      delegate.handle(event);
+    }
   }
 
   static class RollingCounter {

--- a/src/test/java/io/vertx/circuitbreaker/tests/impl/CircuitBreakerBuilderTest.java
+++ b/src/test/java/io/vertx/circuitbreaker/tests/impl/CircuitBreakerBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.circuitbreaker.tests.impl;
+
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.circuitbreaker.CircuitBreakerState;
+import io.vertx.core.Vertx;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+
+public class CircuitBreakerBuilderTest {
+
+  private CircuitBreaker breaker;
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    if (breaker != null) {
+      breaker.close();
+    }
+    AtomicBoolean completed = new AtomicBoolean();
+    vertx.close().onComplete(ar -> completed.set(ar.succeeded()));
+    await().untilAtomic(completed, is(true));
+  }
+
+  @Test
+  public void testBuiltBreakerUsesConfiguredOptionsAndInvokesHandler() {
+    AtomicInteger openCount = new AtomicInteger();
+
+    breaker = CircuitBreaker.builder("test", vertx)
+      .with(new CircuitBreakerOptions().setMaxFailures(1).setResetTimeout(-1))
+      .openHandler(v -> openCount.incrementAndGet())
+      .build();
+
+    assertEquals("test", breaker.name());
+    assertEquals(CircuitBreakerState.CLOSED, breaker.state());
+
+    breaker.open();
+
+    await().untilAtomic(openCount, is(1));
+    assertEquals(CircuitBreakerState.OPEN, breaker.state());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testHandlerSetThroughBuilderCannotBeChanged() {
+    breaker = CircuitBreaker.builder("test", vertx)
+      .openHandler(v -> {
+      })
+      .build();
+
+    breaker.openHandler(v -> {
+    });
+  }
+
+  @Test
+  public void testHandlerNotSetThroughBuilderStaysMutable() {
+    breaker = CircuitBreaker.builder("test", vertx)
+      .openHandler(v -> {
+      })
+      .build();
+
+    // closeHandler was never supplied to the builder, so it should remain freely settable, more than once.
+    breaker.closeHandler(v -> {
+    });
+    breaker.closeHandler(v -> {
+    });
+  }
+
+  @Test
+  public void testLegacyCreateKeepsHandlersMutable() {
+    AtomicInteger openCount = new AtomicInteger();
+
+    breaker = CircuitBreaker.create("test", vertx);
+    breaker.openHandler(v -> openCount.set(1));
+    breaker.openHandler(v -> openCount.set(2));
+
+    breaker.open();
+
+    await().untilAtomic(openCount, is(2));
+  }
+}


### PR DESCRIPTION
Motivation:

Moves handlers away from synchronized by making them final, but allowing mutation via delegate if not provided at construction time.

Mentioned in https://github.com/vert-x3/vertx-circuit-breaker/pull/88#pullrequestreview-4785474187